### PR TITLE
Add 0.5x resolution setting

### DIFF
--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -257,6 +257,7 @@
 
     <!-- Internal Resolution Preference -->
     <string-array name="internalResolutionEntries" translatable="false">
+        <item>0.5x Native (320x264)</item>
         <item>1x Native (640x528)</item>
         <item>1.5x Native (960x792)</item>
         <item>2x Native (1280x1056) for 720p</item>
@@ -268,6 +269,7 @@
         <item>6x Native (3840x3168) for 4K</item>
     </string-array>
     <integer-array name="internalResolutionValues" translatable="false">
+        <item>50</item>
         <item>100</item>
         <item>150</item>
         <item>200</item>


### PR DESCRIPTION
Disclaimer: **I did NOT test this before sending the PR** and I do not know if it even works. It seemed like a simple enough change, so hopefully it is. I've tried setting the internal resolution manually on the .ini file to 50 and it does work.

Running the game at 0.5x the native resolution gives a noticeable performance boost, specially for low-end devices. Please, give this PR a try before merging.